### PR TITLE
feat(generator): Emit const objects for named string enums

### DIFF
--- a/src/core/actions/status.ts
+++ b/src/core/actions/status.ts
@@ -13,6 +13,12 @@ import { formatError } from "../errors.js";
 import { hasLocalSpec, loadCacheMetadata, loadLocalSpec } from "../fetcher.js";
 import type { CacheMetadata } from "../fetcher.js";
 import { HTTP_METHODS } from "../http-methods.js";
+import {
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../local-resolution.js";
+import type { ExecutionSource } from "../local-resolution.js";
 
 /**
  * Options for the status action.
@@ -59,6 +65,8 @@ export interface StatusResult {
 	methodCounts: MethodCounts | null;
 	fileStatus: FileStatus;
 	projectRoot: string;
+	/** Whether the running CLI is the project-local install or a global one. */
+	executionSource: ExecutionSource;
 }
 
 /**
@@ -176,6 +184,12 @@ export async function executeStatus(
 			: null;
 		const fileStatus = await checkGeneratedFiles(outputPaths);
 
+		// Which install is actually running — project-local or global.
+		const runtimeSource = executionSource({
+			runningRoot: findRunningPackageRoot(import.meta.url),
+			localRoot: resolveLocalInstall(process.cwd())?.root ?? null,
+		});
+
 		// Resolve displayed source: prefer local spec_file when set, else api_endpoint.
 		const isLocalSpec = Boolean(config.spec_file);
 		const endpoint = isLocalSpec
@@ -193,6 +207,7 @@ export async function executeStatus(
 			methodCounts,
 			fileStatus,
 			projectRoot,
+			executionSource: runtimeSource,
 		};
 	} catch (error) {
 		logger.error(formatError(error));

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -639,6 +639,66 @@ function formatPropertyKey(name: string): string {
 }
 
 /**
+ * Derives an identifier key for an enum-const entry from the enum value
+ * (`school-staff` → `SCHOOL_STAFF`). Falls back to the quoted value when the
+ * derivation is empty or collides with a key already used in the same const
+ * (e.g. `school-staff` vs `school_staff`).
+ */
+function enumConstKey(value: string, used: Set<string>): string {
+	const derived = value
+		.replace(/[^a-zA-Z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.toUpperCase();
+	const key = /^[0-9]/.test(derived) ? `_${derived}` : derived;
+	if (!key || used.has(key)) return JSON.stringify(value);
+	used.add(key);
+	return key;
+}
+
+/**
+ * Emits `export const <Owner><Prop> = { ... } as const` objects for the
+ * inline all-string enum properties of an object schema. Enums that only
+ * exist as property enums (never as named component schemas) are erased with
+ * the union type, so without this there is no runtime form to iterate or
+ * reference — the gap that forces hand-written frontend mirrors. Properties
+ * that `$ref` a named enum schema are skipped here: the named schema already
+ * gets its own const. Issue #119.
+ */
+function buildPropertyEnumConsts(
+	ownerName: string,
+	schemaObj: Record<string, unknown>,
+	declaredConstNames: Set<string>,
+): string[] {
+	const properties = schemaObj.properties as Record<string, Record<string, unknown>> | undefined;
+	if (!properties) return [];
+	const lines: string[] = [];
+	for (const [propKey, propSchema] of Object.entries(properties)) {
+		if (!propSchema || typeof propSchema !== "object") continue;
+		const values = propSchema.enum;
+		if (
+			!Array.isArray(values) ||
+			values.length === 0 ||
+			!values.every((v) => typeof v === "string")
+		) {
+			continue;
+		}
+		const constName = `${ownerName}${toPascalCase(sanitizeIdentifier(propKey))}`;
+		if (declaredConstNames.has(constName)) {
+			lines.push(`// Enum const for ${ownerName}.${escapeJsdoc(propKey)} — name ${constName} already declared above; skipped.`);
+			continue;
+		}
+		declaredConstNames.add(constName);
+		const usedKeys = new Set<string>();
+		lines.push(`export const ${constName} = {`);
+		for (const value of [...new Set(values as string[])]) {
+			lines.push(`\t${enumConstKey(value, usedKeys)}: ${JSON.stringify(value)},`);
+		}
+		lines.push(`} as const;`);
+	}
+	return lines;
+}
+
+/**
  * Escapes the JSDoc comment terminator inside a string so it can't close a
  * surrounding `/* ... *\/` block. The replacement is unchanged when the
  * comment is read but the parser no longer matches the literal two-char
@@ -1003,6 +1063,23 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 	// declarations of the same name.
 	const declaredNames = new Set<string>();
 
+	// Value-namespace declarations (enum consts). Pre-seeded with the const
+	// names of top-level string-enum schemas so a property-derived const
+	// emitted earlier in the loop can't collide with one declared later.
+	const declaredConstNames = new Set<string>();
+	for (const [name, schema] of Object.entries(metadata.schemas)) {
+		const s = schema as Record<string, unknown>;
+		if (
+			s.type !== "object" &&
+			!s.properties &&
+			Array.isArray(s.enum) &&
+			s.enum.length > 0 &&
+			s.enum.every((v) => typeof v === "string")
+		) {
+			declaredConstNames.add(sanitizeIdentifier(name));
+		}
+	}
+
 	// ~ ======= Schema Models ======= ~
 	const schemaEntries = Object.entries(metadata.schemas);
 	if (schemaEntries.length > 0) {
@@ -1035,6 +1112,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 						lines.push(`\t${formatPropertyKey(propKey)}${optional}: ${propType};`);
 					}
 					lines.push(`}`);
+					lines.push(...buildPropertyEnumConsts(typeName, schemaObj, declaredConstNames));
 				} else {
 					lines.push(`export type ${typeName} = Record<string, unknown>;`);
 				}
@@ -1135,6 +1213,11 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 			lines.push(`/** Request body: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} */`);
 			if (schema) {
 				lines.push(`export type ${typeName} = ${schemaToTS(schema, "", allSchemas, undefined, allComponents)};`);
+				// Inline body objects only — a `$ref` body's enum consts are
+				// emitted with the referenced Schema Model above.
+				if (!schema.$ref) {
+					lines.push(...buildPropertyEnumConsts(typeName, schema, declaredConstNames));
+				}
 			} else {
 				lines.push(`export type ${typeName} = unknown;`);
 			}

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -1041,6 +1041,23 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 			} else {
 				const tsType = schemaToTS(schemaObj, "", allSchemas, undefined, allComponents);
 				lines.push(`export type ${typeName} = ${tsType};`);
+				// Named string enum → additionally emit a runtime const object
+				// (a type alias and a const may share a name) so consumers can
+				// iterate/reference values without hand-writing a mirror —
+				// erased unions have no runtime values. Non-string / mixed
+				// enums stay union-only. Issue #119.
+				if (
+					Array.isArray(schemaObj.enum) &&
+					schemaObj.enum.length > 0 &&
+					schemaObj.enum.every((v) => typeof v === "string")
+				) {
+					const values = [...new Set(schemaObj.enum as string[])];
+					lines.push(`export const ${typeName} = {`);
+					for (const value of values) {
+						lines.push(`\t${formatPropertyKey(value)}: ${JSON.stringify(value)},`);
+					}
+					lines.push(`} as const;`);
+				}
 			}
 			lines.push(``);
 		}

--- a/src/core/local-resolution.ts
+++ b/src/core/local-resolution.ts
@@ -1,0 +1,128 @@
+/**
+ * Local-first execution resolution.
+ *
+ * When the globally-installed `chowbea-axios` is run inside a project that has
+ * its own copy as a dependency, the CLI hands off to that project-local copy so
+ * the pinned version is what actually runs (mirroring how the router already
+ * re-execs itself under Bun). These helpers decide whether to delegate and
+ * report which install is running, kept pure so they can be unit-tested with
+ * injected paths.
+ */
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface LocalInstall {
+	/** Canonical root of the project-local `chowbea-axios` package. */
+	root: string;
+	/** Absolute path to its `bin` entry. */
+	binPath: string;
+}
+
+export type ExecutionSource = "project" | "global";
+
+export type DelegationDecision =
+	| { action: "run" }
+	| { action: "delegate"; binPath: string };
+
+/**
+ * Decide whether the running process should hand off to a project-local
+ * install. Pure: the caller resolves `runningRoot` and `localInstall` (both
+ * canonicalised) and passes argv/env.
+ */
+export function decideDelegation(params: {
+	runningRoot: string;
+	localInstall: LocalInstall | null;
+	argv: string[];
+	env: NodeJS.ProcessEnv;
+}): DelegationDecision {
+	const { runningRoot, localInstall, argv, env } = params;
+
+	// Loop guard: a delegated child must never delegate again.
+	if (env.CHOWBEA_LOCAL_DELEGATED === "1") return { action: "run" };
+	// User opt-outs.
+	if (env.CHOWBEA_NO_DELEGATE === "1") return { action: "run" };
+	if (argv.includes("--global")) return { action: "run" };
+
+	if (!localInstall) return { action: "run" }; // no project-local copy
+	if (localInstall.root === runningRoot) return { action: "run" }; // already it
+
+	return { action: "delegate", binPath: localInstall.binPath };
+}
+
+/**
+ * Whether the currently-running install is the project-local one or a global
+ * one. Pure string comparison of canonicalised roots.
+ */
+export function executionSource(params: {
+	runningRoot: string;
+	localRoot: string | null;
+}): ExecutionSource {
+	const { runningRoot, localRoot } = params;
+	if (!localRoot) return "global";
+	return localRoot === runningRoot ? "project" : "global";
+}
+
+/** Canonicalise a path (resolve symlinks); fall back to the input on failure. */
+function canonical(p: string): string {
+	try {
+		return realpathSync(p);
+	} catch {
+		return p;
+	}
+}
+
+/**
+ * Find the package root of the running CLI by walking up from a module's
+ * `import.meta.url` to the nearest `package.json`. Depth-independent, so it
+ * works from `dist/router.js`, `dist/tui/screens/home.js`, or source.
+ */
+export function findRunningPackageRoot(importMetaUrl: string): string {
+	let dir = dirname(fileURLToPath(importMetaUrl));
+	while (true) {
+		if (existsSync(join(dir, "package.json"))) return canonical(dir);
+		const parent = dirname(dir);
+		if (parent === dir) return canonical(dir); // filesystem root — give up
+		dir = parent;
+	}
+}
+
+/**
+ * Resolve the project-local `chowbea-axios` install for a working directory by
+ * walking up the `node_modules` chain — returning its canonical root and `bin`
+ * entry, or `null` if the project has no local copy.
+ *
+ * A manual walk (rather than `require.resolve`) is deliberate: the running CLI
+ * is itself named `chowbea-axios`, so `require.resolve("chowbea-axios/...")`
+ * would self-reference the running package (and hit its `exports` map) instead
+ * of finding the project-local dependency.
+ */
+export function resolveLocalInstall(cwd: string): LocalInstall | null {
+	let dir = canonical(cwd);
+	while (true) {
+		const pkgJsonPath = join(
+			dir,
+			"node_modules",
+			"chowbea-axios",
+			"package.json",
+		);
+		if (existsSync(pkgJsonPath)) {
+			try {
+				const root = canonical(dirname(pkgJsonPath));
+				const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+					bin?: string | Record<string, string>;
+				};
+				const binRel =
+					typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.["chowbea-axios"];
+				if (!binRel) return null;
+				return { root, binPath: join(root, binRel) };
+			} catch {
+				return null;
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return null; // filesystem root — no local copy
+		dir = parent;
+	}
+}

--- a/src/headless/formatters.ts
+++ b/src/headless/formatters.ts
@@ -37,6 +37,16 @@ export function formatStatusOutput(result: StatusResult): string {
 	lines.push(`  ${pc.bold("chowbea-axios status")}`);
 	lines.push("");
 
+	// Which install is running — project-local vs global.
+	const runLabel =
+		result.executionSource === "project"
+			? pc.green("project install")
+			: pc.dim("global install");
+	lines.push(
+		`  ${pc.cyan("●")} ${pc.bold(pc.cyan(pad("running")))}${runLabel}`,
+	);
+	lines.push("");
+
 	// Config section
 	lines.push(
 		`  ${pc.cyan("\u25cf")} ${pc.bold(pc.cyan(pad("config")))}${result.configPath}${result.wasCreated ? pc.yellow(" (created)") : ""}`,

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -18,6 +18,11 @@ import type { FetchActionOptions } from "../core/actions/fetch.js";
 import { executeGenerate } from "../core/actions/generate.js";
 import type { GenerateActionOptions } from "../core/actions/generate.js";
 import { executeStatus } from "../core/actions/status.js";
+import {
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../core/local-resolution.js";
 import { executeDiff } from "../core/actions/diff.js";
 import { executeValidate } from "../core/actions/validate.js";
 import { executeWatch } from "../core/actions/watch.js";
@@ -758,7 +763,9 @@ export async function runHeadless(
 	args: string[],
 ): Promise<void> {
 	// Strip the command name and global-only flags from args for sub-parsers
-	const commandArgs = args.filter((a) => a !== command && a !== "--headless");
+	const commandArgs = args.filter(
+		(a) => a !== command && a !== "--headless" && a !== "--global",
+	);
 
 	// --version
 	if (args.includes("--version")) {
@@ -769,7 +776,11 @@ export async function runHeadless(
 			const thisDir = dirname(fileURLToPath(import.meta.url));
 			const pkgPath = resolve(thisDir, "..", "..", "package.json");
 			const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
-			console.log(`chowbea-axios v${pkg.version}`);
+			const source = executionSource({
+				runningRoot: findRunningPackageRoot(import.meta.url),
+				localRoot: resolveLocalInstall(process.cwd())?.root ?? null,
+			});
+			console.log(`chowbea-axios v${pkg.version} (${source})`);
 		} catch {
 			console.log("chowbea-axios (unknown version)");
 		}

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,11 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
 import { commandExists, resolveCommand } from "./core/pm.js";
+import {
+	decideDelegation,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "./core/local-resolution.js";
 
 /**
  * Check if Bun is available on the system.
@@ -43,9 +48,49 @@ function relaunchWithBun(argv: string[]): boolean {
 }
 
 /**
+ * Local-first execution. If the working directory has its own chowbea-axios
+ * install and we are NOT it (i.e. the global one is running), hand off to the
+ * project-local bin so the pinned version runs. Mirrors relaunchWithBun: on
+ * delegation the child runs to completion and we exit with its status; if the
+ * spawn itself fails we warn and continue with the current process.
+ */
+function maybeDelegateToLocal(argv: string[]): void {
+	const decision = decideDelegation({
+		runningRoot: findRunningPackageRoot(import.meta.url),
+		localInstall: resolveLocalInstall(process.cwd()),
+		argv,
+		env: process.env,
+	});
+	if (decision.action !== "delegate") return;
+
+	// No `shell: true` — user argv flows through unescaped. The sentinel env var
+	// stops the delegated child from delegating back. Issue #16.
+	const result = spawnSync(
+		process.execPath,
+		[decision.binPath, ...argv.slice(2)],
+		{
+			stdio: "inherit",
+			env: { ...process.env, CHOWBEA_LOCAL_DELEGATED: "1" },
+		},
+	);
+
+	if (result.error) {
+		console.error(
+			`chowbea-axios: could not run the project-local install ` +
+				`(${result.error.message}); continuing with the global one.`,
+		);
+		return;
+	}
+	process.exit(result.status ?? 0);
+}
+
+/**
  * Command router -- dispatches to TUI dashboard or headless CLI.
  */
 export async function route(argv: string[]): Promise<void> {
+	// Local-first: hand off to a project-local install before anything else.
+	maybeDelegateToLocal(argv);
+
 	const args = argv.slice(2); // strip runtime and script path
 	const command = args.find((a) => !a.startsWith("-"));
 	const hasFlag =

--- a/src/router.ts
+++ b/src/router.ts
@@ -81,7 +81,16 @@ function maybeDelegateToLocal(argv: string[]): void {
 		);
 		return;
 	}
-	process.exit(result.status ?? 0);
+	if (typeof result.status === "number") {
+		process.exit(result.status);
+	}
+	if (result.signal) {
+		// The child was killed by a signal — re-raise it so we terminate the
+		// same way instead of masking it as a clean (exit 0) success.
+		process.kill(process.pid, result.signal);
+		return;
+	}
+	process.exit(1);
 }
 
 /**

--- a/src/tui/screens/home.tsx
+++ b/src/tui/screens/home.tsx
@@ -121,6 +121,7 @@ export function HomeScreen() {
 				<box flexDirection="row">
 					<text fg={colors.fgDim}>{`  ${TAGLINE}  `}</text>
 					<text fg={colors.accent}>{`v${version}`}</text>
+					<text fg={result.executionSource === "project" ? colors.success : colors.fgDim}>{`  ·  ${result.executionSource}`}</text>
 				</box>
 			</box>
 

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -1144,6 +1144,11 @@ export type Create_itemBody = {
 	name: "a\\"b" | "c\\\\d" | "normal";
 	"hub.mode"?: string;
 };
+export const Create_itemBodyName = {
+	A_B: "a\\"b",
+	C_D: "c\\\\d",
+	NORMAL: "normal",
+} as const;
 
 // Request body: POST /ping — name already declared as a Schema Model above; skipped.
 
@@ -1396,6 +1401,11 @@ export interface Pet {
 	tag?: string;
 	status?: "available" | "pending" | "sold";
 }
+export const PetStatus = {
+	AVAILABLE: "available",
+	PENDING: "pending",
+	SOLD: "sold",
+} as const;
 
 /**
  * Schema: NewPet

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -53,6 +53,28 @@ describe("generator: end-to-end snapshots", () => {
 						},
 					},
 				},
+				"/tokens": {
+					post: {
+						operationId: "createRealtimeSubscriptionToken",
+						requestBody: {
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										required: ["kind"],
+										properties: {
+											kind: {
+												type: "string",
+												enum: ["campus-staff", "school-staff"],
+											},
+										},
+									},
+								},
+							},
+						},
+						responses: { "200": { description: "ok" } },
+					},
+				},
 			},
 			components: {
 				schemas: {
@@ -61,6 +83,18 @@ describe("generator: end-to-end snapshots", () => {
 						enum: ["invalidate", "refresh", "hub.mode"],
 					},
 					Mixed: { enum: ["a", 1, null] },
+					AuthMeRuleDto: {
+						type: "object",
+						required: ["action"],
+						properties: {
+							action: {
+								type: "string",
+								enum: ["manage", "school-staff", "school_staff", "2fa"],
+							},
+							inverted: { type: "boolean" },
+							count: { enum: [1, 2] },
+						},
+					},
 				},
 			},
 		};
@@ -77,6 +111,23 @@ describe("generator: end-to-end snapshots", () => {
 			// Mixed (non-all-string) enums stay a plain union type, no const.
 			expect(contracts).toContain('export type Mixed = "a" | 1 | null;');
 			expect(contracts).not.toContain("export const Mixed");
+			// Inline property enums on object schemas get <Owner><Prop> consts
+			// with value-derived SCREAMING_SNAKE keys; empty/colliding
+			// derivations fall back to the quoted value; non-string property
+			// enums get nothing.
+			expect(contracts).toContain("export const AuthMeRuleDtoAction = {");
+			expect(contracts).toContain('\tMANAGE: "manage",');
+			expect(contracts).toContain('\tSCHOOL_STAFF: "school-staff",');
+			expect(contracts).toContain('\t"school_staff": "school_staff",');
+			expect(contracts).toContain('\t_2FA: "2fa",');
+			expect(contracts).not.toContain("AuthMeRuleDtoCount");
+			expect(contracts).not.toContain("AuthMeRuleDtoInverted");
+			// Inline request-body objects get the same treatment, named after
+			// the generated Body type.
+			expect(contracts).toContain(
+				"export const CreateRealtimeSubscriptionTokenBodyKind = {",
+			);
+			expect(contracts).toContain('\tCAMPUS_STAFF: "campus-staff",');
 		} finally {
 			await cleanup();
 		}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -33,6 +33,55 @@ describe("generator: end-to-end snapshots", () => {
 		}
 	});
 
+	it("#119: named string enums emit a runtime const object + derived union; mixed enums stay union-only", async () => {
+		const spec = {
+			openapi: "3.0.3",
+			info: { title: "Enums", version: "1.0.0" },
+			paths: {
+				"/actions": {
+					get: {
+						operationId: "listActions",
+						responses: {
+							"200": {
+								description: "ok",
+								content: {
+									"application/json": {
+										schema: { $ref: "#/components/schemas/Action" },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			components: {
+				schemas: {
+					Action: {
+						type: "string",
+						enum: ["invalidate", "refresh", "hub.mode"],
+					},
+					Mixed: { enum: ["a", 1, null] },
+				},
+			},
+		};
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			// The plain union alias is unchanged — the const is purely additive.
+			expect(contracts).toContain(
+				'export type Action = "invalidate" | "refresh" | "hub.mode";',
+			);
+			// Runtime const with value-keyed entries; non-identifier keys quoted.
+			expect(contracts).toContain("export const Action = {");
+			expect(contracts).toContain('\tinvalidate: "invalidate",');
+			expect(contracts).toContain('\t"hub.mode": "hub.mode",');
+			// Mixed (non-all-string) enums stay a plain union type, no const.
+			expect(contracts).toContain('export type Mixed = "a" | 1 | null;');
+			expect(contracts).not.toContain("export const Mixed");
+		} finally {
+			await cleanup();
+		}
+	});
+
 	it("operations header omits the volatile 'Total operations' stat (merge-conflict noise)", async () => {
 		const spec = await loadFixture("petstore.json");
 		const { operations, cleanup } = await runGenerator(spec);

--- a/tests/local-resolution.test.ts
+++ b/tests/local-resolution.test.ts
@@ -1,0 +1,166 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+	decideDelegation,
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../src/core/local-resolution.js";
+
+const GLOBAL_ROOT = "/usr/local/lib/node_modules/chowbea-axios";
+const LOCAL_ROOT = "/work/proj/node_modules/chowbea-axios";
+const LOCAL_BIN = "/work/proj/node_modules/chowbea-axios/bin/chowbea-axios.js";
+const localInstall = { root: LOCAL_ROOT, binPath: LOCAL_BIN };
+
+describe("decideDelegation", () => {
+	it("delegates to the local bin when a local install differs from the running one", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli", "status"],
+				env: {},
+			}),
+		).toEqual({ action: "delegate", binPath: LOCAL_BIN });
+	});
+
+	it("runs as-is when there is no local install", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall: null,
+				argv: ["node", "cli"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("runs as-is when the running install already IS the local one", () => {
+		expect(
+			decideDelegation({
+				runningRoot: LOCAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when the loop-guard sentinel is set", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: { CHOWBEA_LOCAL_DELEGATED: "1" },
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when CHOWBEA_NO_DELEGATE=1", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: { CHOWBEA_NO_DELEGATE: "1" },
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when --global is passed", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli", "--global", "status"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+});
+
+describe("executionSource", () => {
+	it("is 'project' when the running root is the local install", () => {
+		expect(executionSource({ runningRoot: LOCAL_ROOT, localRoot: LOCAL_ROOT })).toBe(
+			"project",
+		);
+	});
+
+	it("is 'global' when a local exists but differs from the running root", () => {
+		expect(
+			executionSource({ runningRoot: GLOBAL_ROOT, localRoot: LOCAL_ROOT }),
+		).toBe("global");
+	});
+
+	it("is 'global' when there is no local install", () => {
+		expect(executionSource({ runningRoot: GLOBAL_ROOT, localRoot: null })).toBe(
+			"global",
+		);
+	});
+});
+
+describe("findRunningPackageRoot", () => {
+	it("walks up from a nested file to the nearest package.json", () => {
+		const root = mkdtempSync(join(tmpdir(), "chowbea-prr-"));
+		try {
+			writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x" }));
+			const deep = join(root, "dist", "tui", "screens");
+			mkdirSync(deep, { recursive: true });
+			const file = join(deep, "home.js");
+			writeFileSync(file, "");
+			expect(findRunningPackageRoot(pathToFileURL(file).href)).toBe(
+				realpathSync(root),
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveLocalInstall", () => {
+	it("finds the project-local install and resolves its bin entry", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-"));
+		try {
+			const pkgRoot = join(cwd, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: { "chowbea-axios": "bin/chowbea-axios.js" },
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+
+			const result = resolveLocalInstall(cwd);
+			expect(result).not.toBeNull();
+			expect(result?.root).toBe(realpathSync(pkgRoot));
+			expect(result?.binPath).toBe(
+				join(realpathSync(pkgRoot), "bin", "chowbea-axios.js"),
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null when there is no project-local install", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-none-"));
+		try {
+			expect(resolveLocalInstall(cwd)).toBeNull();
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/local-resolution.test.ts
+++ b/tests/local-resolution.test.ts
@@ -163,4 +163,50 @@ describe("resolveLocalInstall", () => {
 			rmSync(cwd, { recursive: true, force: true });
 		}
 	});
+
+	it("walks up parent directories to find a hoisted install", () => {
+		const root = mkdtempSync(join(tmpdir(), "chowbea-rli-nested-"));
+		try {
+			const pkgRoot = join(root, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: { "chowbea-axios": "bin/chowbea-axios.js" },
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+			const nested = join(root, "packages", "app", "src");
+			mkdirSync(nested, { recursive: true });
+
+			expect(resolveLocalInstall(nested)?.root).toBe(realpathSync(pkgRoot));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves a string-form bin field", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-str-"));
+		try {
+			const pkgRoot = join(cwd, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: "bin/chowbea-axios.js",
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+
+			expect(resolveLocalInstall(cwd)?.binPath).toBe(
+				join(realpathSync(pkgRoot), "bin", "chowbea-axios.js"),
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Why

OpenAPI enums are emitted as type-level unions only, which are erased at runtime. Any frontend that needs enum *values* — iterating channel kinds, building selects, mapping CASL actions — has to hand-write a const mirror that silently drifts from the spec. With the generator emitting the const, every enum is API-derived in both directions: values exist at runtime, and a spec rename/removal breaks consumers at compile time after regen. The two motivating consumers are property enums (`AuthMeRuleDto.action`, `CreateRealtimeSubscriptionTokenBody.kind`), so coverage includes inline property enums, not just named component schemas.

## What changed

- `src/core/generator.ts:1040` — named all-string enum schemas additionally emit a runtime `const` object after the (unchanged, byte-identical) union type alias. A type alias and a const legally share a name, so this is purely additive; `import type` consumers are unaffected.
- `src/core/generator.ts:641` — new helpers `enumConstKey` (value-derived SCREAMING_SNAKE keys: `school-staff` → `SCHOOL_STAFF`, `2fa` → `_2FA`, quoted-value fallback on empty/colliding derivations) and `buildPropertyEnumConsts` (emits `<Owner><Prop>` consts for inline all-string enum properties of object schemas).
- `src/core/generator.ts` (Schema Models + Operation Request Bodies passes) — object schemas and inline body objects run through `buildPropertyEnumConsts`; `$ref` properties/bodies are skipped since the referenced named schema owns its const; const names are collision-guarded via a pre-seeded `declaredConstNames` set.
- `tests/generator.test.ts` — new test pinning the unchanged union alias, named-enum const emission, quoted non-identifier keys, mixed-enum fallback (no const), DTO property consts, inline-body consts, and numeric-property exclusion.
- `tests/generator.test.snap` — two snapshots gain the new consts (`PetStatus`, `Create_itemBodyName`), confirming escaped values (`"a\"b"`) stay safe through the const path.

Not covered (no known consumer yet): enum properties on inline response objects and query params — the same helper drops in if needed.

## Test plan

- [x] `npm test` — 173/173 across 17 files, including the new #119 test
- [x] `npx vitest run generator -u` — reviewed both snapshot diffs before accepting; only the intended const additions
- [x] `npm run test:types` — 30/30, no type errors
- [x] `npm run build` — clean `tsc`
- [x] Verified fixtures contain no standalone enum schemas, so the named-enum path is covered by the new inline-spec test rather than snapshot churn

## Sources / related

- Closes #119
- Key-escaping approach follows the injection-safety pattern from #15 (`JSON.stringify` for values, `formatPropertyKey` for keys)