### PR TITLE
fix(ci): Update repo slug after rename so release-please runs again

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Defense-in-depth: only run on the canonical repo.
-    if: github.repository == 'oddFEELING/chowbea-axios'
+    if: github.repository == 'ToniChowBea/chowbea-axios'
     steps:
       - name: Run release-please
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
     # not forks or accidental tag mirrors. (Trusted Publisher config on
     # npmjs is already scoped to this repo, but the extra guard avoids
     # spending CI minutes on doomed publishes from forks.)
-    if: github.repository == 'oddFEELING/chowbea-axios'
+    if: github.repository == 'ToniChowBea/chowbea-axios'
     env:
       # Unified tag reference for both triggers:
       #   - push:tags        → github.ref_name is the tag (e.g. "v2.0.0")

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/oddFEELING/chowbea-axios/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/oddFEELING/chowbea-axios/ci.yml?branch=main&style=flat-square&color=10b981" alt="CI" /></a>
-  <a href="https://github.com/oddFEELING/chowbea-axios/stargazers"><img src="https://img.shields.io/github/stars/oddFEELING/chowbea-axios?style=flat-square&color=10b981" alt="GitHub stars" /></a>
+  <a href="https://github.com/ToniChowBea/chowbea-axios/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/ToniChowBea/chowbea-axios/ci.yml?branch=main&style=flat-square&color=10b981" alt="CI" /></a>
+  <a href="https://github.com/ToniChowBea/chowbea-axios/stargazers"><img src="https://img.shields.io/github/stars/ToniChowBea/chowbea-axios?style=flat-square&color=10b981" alt="GitHub stars" /></a>
   <a href="https://www.npmjs.com/package/chowbea-axios"><img src="https://img.shields.io/npm/v/chowbea-axios?style=flat-square&color=10b981" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/chowbea-axios"><img src="https://img.shields.io/npm/dm/chowbea-axios?style=flat-square&color=10b981" alt="npm downloads" /></a>
-  <a href="https://github.com/oddFEELING/chowbea-axios/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981?style=flat-square" alt="license" /></a>
+  <a href="https://github.com/ToniChowBea/chowbea-axios/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981?style=flat-square" alt="license" /></a>
 </p>
 
 ---
@@ -182,8 +182,8 @@ Scaffold them via `chowbea-axios init --with-vite-plugins` or `chowbea-axios plu
 If chowbea-axios helps you ship faster, consider giving it a star! It helps others discover the project and motivates continued development.
 
 <p align="center">
-  <a href="https://github.com/oddFEELING/chowbea-axios">
-    <img src="https://img.shields.io/badge/⭐_Star_on_GitHub-oddFEELING%2Fchowbea--axios-10b981?style=for-the-badge&logo=github" alt="Star on GitHub" />
+  <a href="https://github.com/ToniChowBea/chowbea-axios">
+    <img src="https://img.shields.io/badge/⭐_Star_on_GitHub-ToniChowBea%2Fchowbea--axios-10b981?style=for-the-badge&logo=github" alt="Star on GitHub" />
   </a>
 </p>
 

--- a/package.json
+++ b/package.json
@@ -75,11 +75,11 @@
   ],
   "homepage": "https://axios.chowbea.com",
   "bugs": {
-    "url": "https://github.com/oddFEELING/chowbea-axios/issues"
+    "url": "https://github.com/ToniChowBea/chowbea-axios/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/oddFEELING/chowbea-axios.git"
+    "url": "git+ssh://git@github.com/ToniChowBea/chowbea-axios.git"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Why

The repo was renamed from `oddFEELING/chowbea-axios` to `ToniChowBea/chowbea-axios`, and both release workflows carry a canonical-repo guard (`if: github.repository == 'oddFEELING/chowbea-axios'`) that no longer matches. Since the rename, every push to `main` skips the release-please job entirely (today's three runs: all `skipped`, ~1s), so no release PR is opened and nothing publishes to npm — #120 merged without triggering a release. `package.json`'s `repository.url` also still points at the old slug, which would fail `npm publish --provenance` even with the guard fixed, since provenance validates `repository.url` against the repo the workflow runs in.

## What changed

- `.github/workflows/release-please.yml:63` — canonical-repo guard updated to `ToniChowBea/chowbea-axios`
- `.github/workflows/release.yml:98` — same guard updated in the manual tag-push fallback workflow
- `package.json` — `repository.url` and `bugs.url` updated to the new slug (required for provenance publishing)
- `README.md` — badge/link URLs and the star-badge label updated; old links redirect but stale slugs invite copy-paste drift

Historical review docs under `docs/reviews/` intentionally left untouched — they are dated records and GitHub redirects the old links.

## Test plan

- [x] `npm test` — 173/173
- [x] `grep -rn "oddFEELING/chowbea-axios" .github package.json README.md` → 0 hits
- [x] Verified via `gh run list` that release-please runs were `success` before the rename and `skipped` after, confirming the guard is the cause
- [ ] After merge: release-please run on `main` is **not** skipped and opens the `chore(main): release 2.2.0` PR

## Sources / related

- Skipped run for the #120 merge: https://github.com/ToniChowBea/chowbea-axios/actions/runs/31750559604
- One manual follow-up outside this PR: the npm Trusted Publisher entry for `chowbea-axios` on npmjs.com is scoped to the old owner/repo and must be updated to `ToniChowBea/chowbea-axios` (workflow filename stays `release-please.yml`), or the publish step will fail OIDC validation even though the workflow now runs.