### PR TITLE
fix(tests): Raise timeout for git-spawning resolve tests flaking on Windows CI

### DIFF
--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// The executeResolve tests spawn a real git repo (init/commit/branch/merge)
+// plus a full generator run per test; Windows CI runners occasionally blow
+// the default 5s budget under load. Issue #123.
+vi.setConfig({ testTimeout: 30_000 });
 
 import { executeResolve, partitionConflicts } from "../src/core/actions/resolve.js";
 import { DEFAULT_CONFIG, generateConfigTemplate } from "../src/core/config.js";


### PR DESCRIPTION
## Why

`tests/resolve.test.ts` intermittently exceeds the default 5s vitest timeout on the windows-latest / Node 20 CI shard (#123) — each `executeResolve` test spawns a real git repo (init/commit/branch/merge) plus a full generator run, and Windows runners execute that chain of process spawns far slower than the POSIX shards. It sniped the `main` runs for the #120 and #122 merges. This also gives release-please a releasable commit to cut 2.4.1 with, re-attempting the npm publish through the primary `release-please.yml` Trusted Publishing path after the v2.4.0 publish failed.

## What changed

- `tests/resolve.test.ts:3` — file-level `vi.setConfig({ testTimeout: 30_000 })` with a comment naming the cause; no per-test churn

## Test plan

- [x] `npx vitest run resolve` — 4/4 locally
- [ ] CI matrix green, including windows-latest / Node 20

## Sources / related

- Fixes #123
- Failed runs: [31750559613](https://github.com/ToniChowBea/chowbea-axios/actions/runs/31750559613), [31751241176](https://github.com/ToniChowBea/chowbea-axios/actions/runs/31751241176)