### PR TITLE
fix(bus): Skip unchanged manifest writes; feat: chowbea-name output naming

### DIFF
--- a/src/core/actions/extract.ts
+++ b/src/core/actions/extract.ts
@@ -35,6 +35,50 @@ export interface ExtractActionResult {
 	typeCount: number;
 	wrote: string | null;
 	diff: BusDiff | null;
+	/** True when extraction produced content identical to the manifest already on disk, so no write happened. */
+	unchanged: boolean;
+}
+
+/** Directories that only ever hold build output or vendored code — never bus sources. */
+const IGNORED_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+	".next",
+	".turbo",
+	".cache",
+	".git",
+]);
+
+/**
+ * Whether a changed path should trigger re-extraction.
+ *
+ * Only project TypeScript sources can contribute bus types. Declaration files
+ * are skipped by the extractor itself (`isDeclarationFile`), and build output
+ * is rewritten constantly by other watchers — a NestJS `dist/**` rebuild emits
+ * `.d.ts` files, which would otherwise re-extract on every single rebuild.
+ */
+export function shouldTriggerExtract(filename: string): boolean {
+	const normalized = filename.split(path.sep).join("/");
+	if (!normalized.endsWith(".ts") && !normalized.endsWith(".tsx")) return false;
+	if (normalized.endsWith(".d.ts")) return false;
+	return !normalized.split("/").some((segment) => IGNORED_DIRS.has(segment));
+}
+
+/**
+ * Hash of the manifest already at `outPath`, or `null` when it is absent or
+ * unreadable. Deliberately a raw parse rather than `parseManifest`: a stale or
+ * malformed artifact should simply mean "rewrite it", not throw.
+ */
+async function readExistingHash(outPath: string): Promise<string | null> {
+	try {
+		const raw = JSON.parse(await readFile(outPath, "utf8")) as { hash?: unknown };
+		return typeof raw.hash === "string" ? raw.hash : null;
+	} catch {
+		return null;
+	}
 }
 
 export async function executeExtract(
@@ -54,7 +98,7 @@ export async function executeExtract(
 				logger.error(`${err.file}:${err.line}  ${err.message}`);
 			}
 			logger.error(`Type bus extraction failed with ${errors.length} error(s).`);
-			return { ok: false, errors, typeCount: 0, wrote: null, diff: null };
+			return { ok: false, errors, typeCount: 0, wrote: null, diff: null, unchanged: false };
 		}
 
 		const typeCount = Object.values(manifest!.barrels).flat().length;
@@ -84,20 +128,30 @@ export async function executeExtract(
 				logger.error(
 					`Type bus removed ${diff.removed.length} type(s) present in the baseline — failing (--fail-on-removed).`,
 				);
-				return { ok: false, errors: [], typeCount, wrote: null, diff };
+				return { ok: false, errors: [], typeCount, wrote: null, diff, unchanged: false };
 			}
 		}
 
 		if (options.check) {
 			logger.done(`Type bus OK — ${typeCount} type(s), no violations.`);
-			return { ok: true, errors: [], typeCount, wrote: null, diff };
+			return { ok: true, errors: [], typeCount, wrote: null, diff, unchanged: false };
 		}
 
 		const outPath = path.resolve(cwd, options.out ?? "chowbea.bus.json");
+
+		// Skip the write when the extracted content matches what is already on
+		// disk. `manifest.hash` covers the barrels only — not `generatedAt` — so
+		// it is stable across runs of unchanged source, mirroring the spec-side
+		// cache. Without this, every watch cycle rewrote an identical file.
+		if ((await readExistingHash(outPath)) === manifest!.hash) {
+			logger.info(`Type bus unchanged — ${typeCount} type(s).`);
+			return { ok: true, errors: [], typeCount, wrote: null, diff, unchanged: true };
+		}
+
 		await mkdir(path.dirname(outPath), { recursive: true });
 		await writeFile(outPath, `${JSON.stringify(manifest, null, "\t")}\n`, "utf8");
 		logger.done(`Wrote ${typeCount} type(s) to ${outPath}`);
-		return { ok: true, errors: [], typeCount, wrote: outPath, diff };
+		return { ok: true, errors: [], typeCount, wrote: outPath, diff, unchanged: false };
 	}
 
 	if (options.watch) {
@@ -106,8 +160,7 @@ export async function executeExtract(
 		let timer: NodeJS.Timeout | null = null;
 		const { watch } = await import("node:fs");
 		const watcher = watch(cwd, { recursive: true }, (_event, filename) => {
-			if (!filename || !filename.endsWith(".ts")) return;
-			if (filename.includes("node_modules") || filename.includes("chowbea.bus.json")) return;
+			if (!filename || !shouldTriggerExtract(filename)) return;
 			if (timer) clearTimeout(timer);
 			timer = setTimeout(() => {
 				void runOnce()

--- a/src/core/bus/extract.ts
+++ b/src/core/bus/extract.ts
@@ -87,6 +87,30 @@ function loadProgram(
 	return { program, rootDir };
 }
 
+/** A `chowbea-name "..."` directive (the leading `@` is optional). */
+const NAME_TAG_PATTERN = /@?chowbea-name\s+["\']([^"\'\r\n]+)["\']/;
+/** Every comment in a file, in source order — block first, then line. */
+const COMMENT_PATTERN = /\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g;
+
+/**
+ * Explicit output name for a file, declared as `chowbea-name "grades"` inside
+ * any comment. It overrides the path-derived barrel key, so the frontend emits
+ * `grades.ts` instead of `exams.grade.ts`.
+ *
+ * The first occurrence in the file wins — later ones are ignored rather than
+ * erroring, so a file can never be ambiguously named.
+ */
+function explicitBarrelName(sf: ts.SourceFile): { name: string; line: number } | null {
+	const text = sf.getFullText();
+	for (const comment of text.matchAll(COMMENT_PATTERN)) {
+		const tag = NAME_TAG_PATTERN.exec(comment[0]);
+		if (!tag) continue;
+		const at = (comment.index ?? 0) + (tag.index ?? 0);
+		return { name: tag[1].trim(), line: sf.getLineAndCharacterOfPosition(at).line + 1 };
+	}
+	return null;
+}
+
 function barrelKey(fileName: string, rootDir: string): string {
 	const rel = toPosix(path.relative(rootDir, fileName));
 	return rel.slice(0, -BARREL_SUFFIX.length);
@@ -181,16 +205,57 @@ export function extractBusTypes(options: { projectRoot: string; tsconfigPath?: s
 		});
 	};
 
+	/** Explicit `chowbea-name` claims: output name -> the sites that claimed it. */
+	const explicitClaims = new Map<string, { file: string; line: number }[]>();
+	/** Every output key -> the files contributing to it (marker files legitimately share one). */
+	const keyContributors = new Map<string, Set<string>>();
+
+	const trackKey = (key: string, relFile: string) => {
+		const files = keyContributors.get(key) ?? new Set<string>();
+		files.add(relFile);
+		keyContributors.set(key, files);
+	};
+
+	/**
+	 * A file's output key: its `chowbea-name` directive when present and valid,
+	 * otherwise the path-derived one. An invalid name is an error that falls back
+	 * to the derived key, so the sweep still reports the file's other problems.
+	 */
+	const resolveKey = (sf: ts.SourceFile, relFile: string, derived: string): string => {
+		const explicit = explicitBarrelName(sf);
+		if (!explicit) return derived;
+		const { name, line } = explicit;
+		const reject = (why: string): string => {
+			errors.push({ message: `chowbea-name "${name}" ${why}`, file: relFile, line });
+			return derived;
+		};
+		if (!isSafeBarrelKey(name)) {
+			return reject(
+				"is not a valid output name — use a plain name like \"grades\" (no leading slash, no \"..\" segments, no backslashes).",
+			);
+		}
+		if (name === "index") {
+			return reject('is reserved — the frontend emits its own index.ts re-export barrel.');
+		}
+		if (name === RESERVED_PREFIX || name.startsWith(`${RESERVED_PREFIX}/`)) {
+			return reject(`is reserved — the "${RESERVED_PREFIX}/" namespace groups @chowbea-export types.`);
+		}
+		explicitClaims.set(name, [...(explicitClaims.get(name) ?? []), { file: relFile, line }]);
+		return name;
+	};
+
 	for (const sf of projectFiles) {
 		const relFile = toPosix(path.relative(options.projectRoot, sf.fileName));
 
 		// Channel 1: *.chowbea.ts barrels — every export is on the bus.
 		if (sf.fileName.endsWith(BARREL_SUFFIX)) {
-			const key = barrelKey(sf.fileName, rootDir);
-			if (!isSafeBarrelKey(key)) {
+			const derived = barrelKey(sf.fileName, rootDir);
+			if (!isSafeBarrelKey(derived)) {
 				errors.push(outOfRootDirError(relFile, rootDir));
 				continue;
 			}
+			const key = resolveKey(sf, relFile, derived);
+			trackKey(key, relFile);
 			const moduleSymbol = checker.getSymbolAtLocation(sf);
 			for (const exp of moduleSymbol ? checker.getExportsOfModule(moduleSymbol) : []) {
 				const resolved = exp.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exp) : exp;
@@ -220,9 +285,10 @@ export function extractBusTypes(options: { projectRoot: string; tsconfigPath?: s
 			if (ts.isTypeAliasDeclaration(stmt) || ts.isInterfaceDeclaration(stmt) || ts.isEnumDeclaration(stmt)) {
 				if (!markedFileKeyChecked) {
 					markedFileKeyChecked = true;
-					const key = markedKey(sf.fileName, rootDir);
-					markedFileKey = isSafeBarrelKey(key) ? key : null;
+					const derived = markedKey(sf.fileName, rootDir);
+					markedFileKey = isSafeBarrelKey(derived) ? resolveKey(sf, relFile, derived) : null;
 					if (markedFileKey === null) errors.push(outOfRootDirError(relFile, rootDir));
+					else trackKey(markedFileKey, relFile);
 				}
 				if (markedFileKey === null) continue;
 				collectDeclaration(stmt, stmt.name.text, markedFileKey, {
@@ -232,6 +298,29 @@ export function extractBusTypes(options: { projectRoot: string; tsconfigPath?: s
 				continue;
 			}
 			errors.push(typesOnlyError(markedStatementName(stmt), relFile, lineOf(stmt)));
+		}
+	}
+
+	// ~ Explicit output names own their file. Two files resolving to one name —
+	// whether both claimed it or one collided with another file's derived key —
+	// would silently merge into a single generated file, so both error.
+	for (const [name, claims] of explicitClaims) {
+		const claimants = [...new Set(claims.map((c) => c.file))];
+		if (claimants.length > 1) {
+			errors.push({
+				message: `chowbea-name "${name}" is claimed by ${claimants.length} files — ${claimants.join(" and ")}. Output names must be unique.`,
+				file: claims[0].file,
+				line: claims[0].line,
+			});
+			continue;
+		}
+		const others = [...(keyContributors.get(name) ?? [])].filter((f) => f !== claimants[0]);
+		if (others.length > 0) {
+			errors.push({
+				message: `chowbea-name "${name}" collides with types already destined for that file from ${others.join(", ")}. Rename one of them.`,
+				file: claims[0].file,
+				line: claims[0].line,
+			});
 		}
 	}
 

--- a/tests/bus-extract-action.test.ts
+++ b/tests/bus-extract-action.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { executeExtract } from "../src/core/actions/extract.js";
+import { executeExtract, shouldTriggerExtract } from "../src/core/actions/extract.js";
 import { parseManifest } from "../src/core/bus/manifest.js";
 import { makeBusFixture } from "./helpers/bus-fixture.js";
 import { SILENT_LOGGER } from "./helpers/logger.js";
@@ -186,4 +186,106 @@ describe("executeExtract --watch", () => {
 			cleanup();
 		}
 	}, 20_000);
+});
+
+describe("executeExtract: manifest caching", () => {
+	it("does not rewrite the manifest when nothing changed", async () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `export type A = 1;\n`,
+		});
+		try {
+			const first = await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			expect(first.unchanged).toBe(false);
+			expect(first.wrote).not.toBeNull();
+			const artifact = join(dir, "chowbea.bus.json");
+			const mtimeBefore = statSync(artifact).mtimeMs;
+
+			const second = await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			expect(second).toMatchObject({ ok: true, unchanged: true, wrote: null, typeCount: 1 });
+			expect(statSync(artifact).mtimeMs).toBe(mtimeBefore);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rewrites when a bus type actually changes", async () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `export type A = 1;\n`,
+		});
+		try {
+			await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			writeFileSync(join(dir, "src", "bus.chowbea.ts"), `export type A = 1;\nexport type B = 2;\n`);
+
+			const result = await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			expect(result).toMatchObject({ unchanged: false, typeCount: 2 });
+			expect(result.wrote).toBe(join(dir, "chowbea.bus.json"));
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rewrites when the manifest is missing, even if the source is unchanged", async () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `export type A = 1;\n`,
+		});
+		try {
+			const artifact = join(dir, "chowbea.bus.json");
+			await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			rmSync(artifact);
+
+			const result = await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			expect(result.unchanged).toBe(false);
+			expect(existsSync(artifact)).toBe(true);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rewrites over a corrupt manifest rather than throwing", async () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `export type A = 1;\n`,
+		});
+		try {
+			const artifact = join(dir, "chowbea.bus.json");
+			writeFileSync(artifact, "{ not json");
+
+			const result = await executeExtract({ cwd: dir }, SILENT_LOGGER);
+			expect(result).toMatchObject({ ok: true, unchanged: false });
+			expect(parseManifest(readFileSync(artifact, "utf8")).chowbeaBus).toBe("1");
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe("shouldTriggerExtract", () => {
+	it("triggers on project TypeScript sources", () => {
+		expect(shouldTriggerExtract("src/bus.chowbea.ts")).toBe(true);
+		expect(shouldTriggerExtract("src/exams/models.ts")).toBe(true);
+		expect(shouldTriggerExtract("src/ui/widget.tsx")).toBe(true);
+	});
+
+	it("ignores build output — the NestJS dist/**.d.ts rebuild storm", () => {
+		expect(shouldTriggerExtract("dist/main.d.ts")).toBe(false);
+		expect(shouldTriggerExtract("dist/exams/grade.js")).toBe(false);
+		expect(shouldTriggerExtract("dist/exams/grade.ts")).toBe(false);
+		expect(shouldTriggerExtract("build/index.ts")).toBe(false);
+		expect(shouldTriggerExtract(".next/types/route.ts")).toBe(false);
+		expect(shouldTriggerExtract("coverage/lcov-report/x.ts")).toBe(false);
+	});
+
+	it("ignores declaration files anywhere — the extractor skips them too", () => {
+		expect(shouldTriggerExtract("src/types/global.d.ts")).toBe(false);
+	});
+
+	it("ignores node_modules and non-TypeScript files", () => {
+		expect(shouldTriggerExtract("node_modules/pkg/index.ts")).toBe(false);
+		expect(shouldTriggerExtract("chowbea.bus.json")).toBe(false);
+		expect(shouldTriggerExtract("src/README.md")).toBe(false);
+	});
+
+	it("does not reject paths that merely contain an ignored name as a substring", () => {
+		expect(shouldTriggerExtract("src/distribution/plans.chowbea.ts")).toBe(true);
+		expect(shouldTriggerExtract("src/outbox/events.ts")).toBe(true);
+	});
 });

--- a/tests/bus-extract.test.ts
+++ b/tests/bus-extract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { renderBusFiles } from "../src/core/bus/emit.js";
 import { extractBusManifest, extractBusTypes } from "../src/core/bus/extract.js";
 import { makeBusFixture } from "./helpers/bus-fixture.js";
 
@@ -358,6 +359,147 @@ describe("extractBusManifest: fidelity + assembly", () => {
 			expect(manifest).toMatchSnapshot();
 		} finally {
 			cleanup();
+		}
+	});
+});
+
+describe("chowbea-name: explicit destination file names", () => {
+	it("overrides the path-derived barrel key for a *.chowbea.ts barrel", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/exams/grade.chowbea.ts": `/** chowbea-name "grades" */\nexport type Grade = "A" | "B";\n`,
+		});
+		try {
+			const out = extractBusTypes({ projectRoot: dir });
+			expect(out.errors).toEqual([]);
+			expect(Object.keys(out.barrels)).toEqual(["grades"]);
+			expect(out.barrels.grades.map((e) => e.name)).toEqual(["Grade"]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("decides the generated filename end to end", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/exams/grade.chowbea.ts": `/** chowbea-name "grades" */\nexport type Grade = "A";\n`,
+		});
+		try {
+			const { manifest, errors } = extractBusManifest({ projectRoot: dir, now: new Date(0) });
+			expect(errors).toEqual([]);
+			expect(Object.keys(renderBusFiles(manifest!)).sort()).toEqual(["grades.ts", "index.ts"]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("accepts the @-prefixed form too", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `/** @chowbea-name "domain" */\nexport type A = 1;\n`,
+		});
+		try {
+			expect(Object.keys(extractBusTypes({ projectRoot: dir }).barrels)).toEqual(["domain"]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("takes the first occurrence when a file declares several", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `/** chowbea-name "first" */\n// chowbea-name "second"\n/** chowbea-name "third" */\nexport type A = 1;\n`,
+		});
+		try {
+			const out = extractBusTypes({ projectRoot: dir });
+			expect(out.errors).toEqual([]);
+			expect(Object.keys(out.barrels)).toEqual(["first"]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("renames a marker-channel file out of the _marked/ grouping", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/billing/plans.ts": `/** chowbea-name "billing" */\n/** @chowbea-export */\nexport interface Plan { name: string }\n`,
+		});
+		try {
+			const out = extractBusTypes({ projectRoot: dir });
+			expect(out.errors).toEqual([]);
+			expect(Object.keys(out.barrels)).toEqual(["billing"]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("supports a nested name, flattened on emission", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/bus.chowbea.ts": `/** chowbea-name "domain/grades" */\nexport type A = 1;\n`,
+		});
+		try {
+			const { manifest, errors } = extractBusManifest({ projectRoot: dir, now: new Date(0) });
+			expect(errors).toEqual([]);
+			expect(Object.keys(renderBusFiles(manifest!))).toContain("domain.grades.ts");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("errors when two files claim the same name", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/a.chowbea.ts": `/** chowbea-name "shared" */\nexport type A = 1;\n`,
+			"src/b.chowbea.ts": `/** chowbea-name "shared" */\nexport type B = 2;\n`,
+		});
+		try {
+			const out = extractBusTypes({ projectRoot: dir });
+			expect(out.errors).toHaveLength(1);
+			expect(out.errors[0].message).toContain('chowbea-name "shared" is claimed by 2 files');
+			expect(out.errors[0].message).toContain("src/a.chowbea.ts");
+			expect(out.errors[0].message).toContain("src/b.chowbea.ts");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("errors when a name collides with another file's derived key", () => {
+		const { dir, cleanup } = makeBusFixture({
+			"src/grades.chowbea.ts": `export type A = 1;\n`,
+			"src/exams/detail.chowbea.ts": `/** chowbea-name "grades" */\nexport type B = 2;\n`,
+		});
+		try {
+			const out = extractBusTypes({ projectRoot: dir });
+			expect(out.errors).toHaveLength(1);
+			expect(out.errors[0].message).toContain("collides with types already destined for that file");
+			expect(out.errors[0].message).toContain("src/grades.chowbea.ts");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rejects reserved names", () => {
+		for (const name of ["index", "_marked", "_marked/billing"]) {
+			const { dir, cleanup } = makeBusFixture({
+				"src/bus.chowbea.ts": `/** chowbea-name "${name}" */\nexport type A = 1;\n`,
+			});
+			try {
+				const out = extractBusTypes({ projectRoot: dir });
+				expect(out.errors).toHaveLength(1);
+				expect(out.errors[0].message).toContain("is reserved");
+			} finally {
+				cleanup();
+			}
+		}
+	});
+
+	it("rejects unsafe names and falls back to the derived key", () => {
+		for (const name of ["../evil", "a\\\\b", "/abs"]) {
+			const { dir, cleanup } = makeBusFixture({
+				"src/bus.chowbea.ts": `/** chowbea-name "${name}" */\nexport type A = 1;\n`,
+			});
+			try {
+				const out = extractBusTypes({ projectRoot: dir });
+				expect(out.errors).toHaveLength(1);
+				expect(out.errors[0].message).toContain("is not a valid output name");
+				expect(Object.keys(out.barrels)).toEqual(["bus"]);
+			} finally {
+				cleanup();
+			}
 		}
 	});
 });


### PR DESCRIPTION
## Why

Two things, both surfaced from a real `extract --watch` session.

**1. `extract` rewrote `chowbea.bus.json` on every run**, even when the extracted types were byte-identical — unlike the spec side, which skips when the hash is unchanged. That produced a stream of identical `Wrote 12 type(s)` writes and needless churn for anything watching the artifact. Two causes: the write was unconditional, and the watcher only ignored `node_modules` and the literal `chowbea.bus.json`, so a NestJS rebuild emitting `dist/**/*.d.ts` (files ending in `.ts`) re-triggered extraction on every compile.

**2. Generated filenames were dictated by source paths.** `src/exams/grade.chowbea.ts` always became `exams.grade.ts` on the client, with no way to choose something better.

## What changed

### Manifest caching

- `src/core/actions/extract.ts` — the write is gated on the manifest content hash. `hash` covers the barrels (name/kind/declaration/source/line) but **not** `generatedAt`, so unchanged source always compares equal. On a match: no write, and `Type bus unchanged — N type(s).` A missing or corrupt manifest is always rewritten (raw `JSON.parse`, not `parseManifest`, so a stale artifact means "rewrite", never a throw).
- `ExtractActionResult` gains `unchanged: boolean`; `wrote` is `null` when the write is skipped.
- New exported `shouldTriggerExtract(filename)` replaces the inline watcher filter: requires `.ts`/`.tsx`, rejects `.d.ts` (the extractor already skips declaration files via `isDeclarationFile`, so they can never contribute a type), and rejects any path **segment** in `node_modules`, `dist`, `build`, `out`, `coverage`, `.next`, `.turbo`, `.cache`, `.git` — so `src/distribution/` and `src/outbox/` still trigger.

The hash gate also closes the theoretical self-retrigger loop: an unchanged extraction performs no write at all.

### `chowbea-name` — explicit destination filenames

A file can now name its own generated output:

```ts
/** chowbea-name "grades" */   // → _generated/bus/grades.ts
```

- The `@` prefix is optional (`@chowbea-name` works), the tag can sit in any comment, and **the first occurrence in a file wins** — a file is never ambiguously named.
- Works on marker-channel files too, lifting those types out of the `_marked/` grouping into a file of their own.
- Nested names are allowed (`"domain/grades"` → `domain.grades.ts`), using the same flattening derived keys get.

**No new manifest field was needed.** Barrel keys already drive the emitted filename, so the directive overrides the key; each entry's `source` still records the real file, so provenance is unchanged.

Validated at extraction: safe-key shape (no leading slash, `..` segments, or backslashes), `index` and the `_marked/` namespace reserved, and **two files resolving to the same output is an error naming both** — whether both claimed the name or one collided with another file's derived key. Silently merging two files into one generated file is exactly what that rule prevents. Invalid names error and fall back to the derived key, so the rest of the sweep still reports its own problems.

## Test plan

- [x] `npm test` — 279/279 (18 new: caching incl. mtime assertion, rewrite-on-change, rewrite-when-deleted, rewrite-over-corrupt; 5 watcher-predicate cases incl. the `dist/**/*.d.ts` storm and substring-vs-segment; 10 `chowbea-name` cases incl. both tag forms, first-wins, marker channel, nested names, duplicate claims, derived-key collision, reserved and unsafe names)
- [x] `npm run build` and `npm run test:types` — clean
- [x] End-to-end with the built CLI: cold run writes → re-run unchanged → touching `dist/main.d.ts` unchanged → real source edit writes 3 types → unchanged again
- [x] End-to-end: `chowbea-name "grades"` produces barrel key `grades` while `source` still reads `src/exams/grade.chowbea.ts`
- [x] Docs updated in the docs repo (caching, watcher ignores, and the naming directive)